### PR TITLE
Add horizontal drag scroll for server cards

### DIFF
--- a/panel.html
+++ b/panel.html
@@ -126,7 +126,7 @@
         <!-- 服务器列表 -->
         <div
           id="server-cards"
-          class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 text-sm mb-4"
+          class="flex gap-4 overflow-x-auto text-sm mb-4 pb-2 cursor-grab active:cursor-grabbing"
         >
           <div
             class="bg-gray-800 p-4 rounded cursor-pointer hover:bg-gray-700"
@@ -425,7 +425,7 @@
           const hostPort = `${s.host}${s.port ? ":" + s.port : ""}`;
           const label = s.tag ? `${s.tag}` : hostPort;
           card.className =
-            "bg-gray-800 rounded-lg p-4 shadow space-y-1 cursor-pointer";
+            "bg-gray-800 rounded-lg p-4 shadow space-y-1 cursor-pointer flex-shrink-0 min-w-[12rem]";
           if (idx === currentServerIndex)
             card.classList.add("ring", "ring-cyan-500");
           card.onclick = () => selectServer(idx);
@@ -805,13 +805,62 @@
         const serverCards = document.getElementById("server-cards");
         serverCards.style.display = document.getElementById("toggleServers")
           .checked
-          ? "grid"
+          ? "flex"
           : "none";
       }
 
       document
         .getElementById("toggleServers")
         .addEventListener("change", applyToggleState);
+
+      // 支持鼠标/触控拖动浏览服务器卡片
+      (function () {
+        const scroller = document.getElementById("server-cards");
+        let isDown = false;
+        let startX = 0;
+        let scrollLeft = 0;
+        let didDrag = false;
+        scroller.addEventListener("mousedown", (e) => {
+          isDown = true;
+          didDrag = false;
+          startX = e.pageX;
+          scrollLeft = scroller.scrollLeft;
+        });
+        scroller.addEventListener("mousemove", (e) => {
+          if (!isDown) return;
+          const walk = e.pageX - startX;
+          if (Math.abs(walk) > 2) didDrag = true;
+          scroller.scrollLeft = scrollLeft - walk;
+        });
+        ["mouseleave", "mouseup"].forEach((ev) =>
+          scroller.addEventListener(ev, () => {
+            isDown = false;
+          })
+        );
+        scroller.addEventListener("click", (e) => {
+          if (didDrag) {
+            e.preventDefault();
+            e.stopPropagation();
+          }
+        });
+        scroller.addEventListener("touchstart", (e) => {
+          isDown = true;
+          didDrag = false;
+          startX = e.touches[0].clientX;
+          scrollLeft = scroller.scrollLeft;
+        });
+        scroller.addEventListener("touchmove", (e) => {
+          if (!isDown) return;
+          const walk = e.touches[0].clientX - startX;
+          if (Math.abs(walk) > 2) didDrag = true;
+          scroller.scrollLeft = scrollLeft - walk;
+        });
+        ["touchend", "touchcancel"].forEach((ev) =>
+          scroller.addEventListener(ev, () => {
+            isDown = false;
+          })
+        );
+      })();
 
       document.getElementById("toggleSSH").addEventListener("change", (e) => {
         useSSH = e.target.checked;


### PR DESCRIPTION
## Summary
- enable scrolling server card list horizontally
- style server cards with min width so they line up horizontally
- allow dragging with mouse or touch to scroll

## Testing
- `deno test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6850d784994c832e9e3cb25ef703547a