### PR TITLE
Keep server card actions visible

### DIFF
--- a/panel.html
+++ b/panel.html
@@ -518,8 +518,13 @@
             const hostPort = `${s.host}${s.port ? ":" + s.port : ""}`;
             const label = s.tag ? `${s.tag}` : hostPort;
             card.innerHTML =
-              `<h3 class="text-cyan-400 mb-1">${label}</h3>` +
-              `<div>CPU: <span class="text-lime-400">${cpu}%</span></div>` +
+              `<div class="flex justify-between items-center">` +
+              `<h3 class="text-cyan-400">${label}</h3>` +
+              `<div class="space-x-2">` +
+              `<button onclick="editServer(event, ${idx})" class="text-yellow-400 hover:text-yellow-300">✎</button>` +
+              `<button onclick="removeServer(event, ${idx})" class="text-red-400 hover:text-red-300">×</button>` +
+              `</div></div>` +
+              `<div class="mt-1">CPU: <span class="text-lime-400">${cpu}%</span></div>` +
               `<div>内存: ${memUsed}/${memTotal} GB</div>` +
               `<div>磁盘: ${diskUsed}/${diskTotal} GB</div>` +
               `<div>流量: ${rx}/${tx} MB</div>` +
@@ -528,8 +533,13 @@
             const hostPort = `${s.host}${s.port ? ":" + s.port : ""}`;
             const label = s.tag ? `${s.tag}` : hostPort;
             card.innerHTML =
-              `<h3 class="text-cyan-400 mb-1">${label}</h3>` +
-              `<div class="text-red-400">${e.message}</div>`;
+              `<div class="flex justify-between items-center">` +
+              `<h3 class="text-cyan-400">${label}</h3>` +
+              `<div class="space-x-2">` +
+              `<button onclick="editServer(event, ${idx})" class="text-yellow-400 hover:text-yellow-300">✎</button>` +
+              `<button onclick="removeServer(event, ${idx})" class="text-red-400 hover:text-red-300">×</button>` +
+              `</div></div>` +
+              `<div class="text-red-400 mt-1">${e.message}</div>`;
           }
         }
       }


### PR DESCRIPTION
## Summary
- keep edit/delete buttons visible when server info loads

## Testing
- `deno test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6850e0de4970832eb748530a2ff356e2